### PR TITLE
The destructor of pdf should be virtual

### DIFF
--- a/pdf.h
+++ b/pdf.h
@@ -49,7 +49,7 @@ class pdf  {
     public:
         virtual float value(const vec3& direction) const = 0;
         virtual vec3 generate() const = 0;
-        ~pdf() {}
+        virtual ~pdf() {}
 };
 
 


### PR DESCRIPTION
In my environment with OSX, this destructor cause EXC_BAD_INSTRUCTION.
So I think it should be virtual.