### PR TITLE
 Truncation when ppm format exceeded upper limit

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -115,9 +115,9 @@ int main() {
             }
             col /= float(ns);
             col = vec3( sqrt(col[0]), sqrt(col[1]), sqrt(col[2]) );
-            int ir = int(255.99*col[0]);
-            int ig = int(255.99*col[1]);
-            int ib = int(255.99*col[2]);
+            int ir = std::min(0xff,int(255.99*col[0]));
+            int ig = std::min(0xff,int(255.99*col[1]));
+            int ib = std::min(0xff,int(255.99*col[2]));
             std::cout << ir << " " << ig << " " << ib << "\n";
         }
     }


### PR DESCRIPTION
Since "int(255.99*col[xx])" can be over 256 in windows environment,
so add std::min for truncation that.