### PR TITLE
Fix cosine-weighted hemisphere sampling

### DIFF
--- a/pdf.h
+++ b/pdf.h
@@ -19,8 +19,8 @@ inline vec3 random_cosine_direction() {
     float r2 = drand48();
     float z = sqrt(1-r2);
     float phi = 2*M_PI*r1;
-    float x = cos(phi)*2*sqrt(r2);
-    float y = sin(phi)*2*sqrt(r2);
+    float x = cos(phi)*sqrt(r2);
+    float y = sin(phi)*sqrt(r2);
     return vec3(x, y, z);
 }
 


### PR DESCRIPTION
Fixes #9.

In chapter 5 of the book, the derivation of cosine-weighted hemisphere sampling correctly defines the following:

```
z = cos(theta) = sqrt(1-r2)
x = cos(phi)*sin(theta) = cos(2*Pi*r1)*sqrt(1-z^2) = cos(2*Pi*r1)*sqrt(r2)
y = sin(phi)*sin(theta) = sin(2*Pi*r1)*sqrt(1-z^2) = sin(2*Pi*r1)*sqrt(r2)
```

But the code snippet right after that (and also in ```pdf.h```) includes a multiply by 2. When rendering the cornell box without mixture PDF (just using `srec.pdf_ptr`), we obtain the following image (pardon the noise. I wanted to make some quick examples, but you can still see the difference):

![out](https://user-images.githubusercontent.com/2500920/59591861-cb2e3300-9129-11e9-8324-5863ffb818e9.jpg)

As Peter Shirley mentioned towards the end of chapter 6, the image certainly looks wrong. Take a look at the light shining on the tall box, for example. It shouldn't be like that, I think.

By removing the factor of 2 from the code (and thus matching the equations above), we get:

![out1](https://user-images.githubusercontent.com/2500920/59591880-d41f0480-9129-11e9-96d7-ecb65d3baea4.jpg)

Which gives a result closer to the final image when rendered with mixture PDF's.

Thanks to [Jamorn Sriwansansak](https://github.com/jamornsriwasansak) for providing a clue to this issue ^^