### PR TITLE
Added the &hlist to the color function in codeblock

### DIFF
--- a/docs/ch11.md.html
+++ b/docs/ch11.md.html
@@ -338,6 +338,17 @@ We assemble a list to pass in to `color`.
     a[0] = light_shape;
     a[1] = glass_sphere;
     hitable_list hlist(a,2);
+
+    for (int j = ny-1; j >= 0; j--) {
+        for (int i = 0; i < nx; i++) {
+            vec3 col(0, 0, 0);
+            for (int s=0; s < ns; s++) {
+                float u = float(i+drand48())/ float(nx);
+                float v = float(j+drand48())/ float(ny);
+                ray r = cam->get_ray(u, v);
+                vec3 p = r.point_at_parameter(2.0);
+                col += color(r, world, &hlist, 0);
+            }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 And we get a decent image with 1000 samples as before:


### PR DESCRIPTION
After 'we assemble a list to pass in to `color`'
Two code changes are made
1.
   *hitable light_shape = new xz_rect(213, 343, 227, 332, 554, 0);
   *hitable glass_sphere = new sphere(vec3(190, 90, 190), 90, 0);
   *hitable a[2];
   a[0] = light_shape;
   a[1] = glass_sphere;
   hitable_list hlist(a,2);
2.
   for (int s=0; s < ns; s++) {
       float u = float(i+drand48())/ float(nx);
       float v = float(j+drand48())/ float(ny);
       ray r = cam->get_ray(u, v);
       vec3 p = r.point_at_parameter(2.0);
   ---    col += color(r, world, glass_sphere 0);
   +++    col += color(r, world, &hlist, 0);
   }

The second part is small. Exceedingly so. But, immediately after change 1, an image is rendered (image 11-3). If the reader doesn't recognize the need to change glass_sphere to hlist. Then the image rendered would not include the light_shape. The effect would be subtle and potentially difficult to notice